### PR TITLE
Refactor: Update daily_build.yml cache strategy for unique per-run ca…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,11 +2,9 @@ name: Build Unity Project
 
 on:
   workflow_run:
-    workflows: ["Run Unity Tests"] # This must match the name in test.yml
+    workflows: ["Run Unity Tests"]
     types:
       - completed
-    branches: # Optional: only run for pushes/PRs to these branches
-      - main
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,15 +1,15 @@
-name: Build Unity Project
+name: CI-Build
 
 on:
   workflow_run:
-    workflows: ["Run Unity Tests"]
+    workflows: ["CI-Test"]
     types:
       - completed
 
 jobs:
   build:
     name: Build Unity Project
-    if: ${{ github.event.workflow_run.conclusion == 'success' }} # Only run if the 'Run Unity Tests' workflow succeeded
+    if: ${{ github.event.workflow_run.conclusion == 'success' }} 
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,12 @@
 name: CI-Build
 
 on:
+  push:
+    branches:
+      - '*'
+  pull_request:
+    branches:
+      - '*'  
   workflow_run:
     workflows: ["CI-Test"]
     types:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,80 +1,35 @@
-name: CI
+name: Build Unity Project
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
+  workflow_run:
+    workflows: ["Run Unity Tests"] # This must match the name in test.yml
+    types:
+      - completed
+    branches: # Optional: only run for pushes/PRs to these branches
       - main
 
 jobs:
-  test:
-    name: Run Unity Tests
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          lfs: true
-
-      - name: Cache Library folder
-        uses: actions/cache@v4
-        with:
-          path: Library
-          key: Library-${{ hashFiles('Assets/**', 'Packages/**', 'ProjectSettings/**') }}
-          restore-keys: |
-            Library-
-
-      - name: Run tests
-        uses: game-ci/unity-test-runner@v4
-        env:
-          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
-          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
-          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
-        with:
-          customImage: unityci/editor:ubuntu-2022.3.6f1-windows-mono-3.0.1
-          testMode: all      # all / editmode / playmode
-          artifactsPath: test-results
-
-      - name: Publish Unity Test Report
-        if: always()       # 即使測試失敗也要發佈報告
-        uses: dorny/test-reporter@v2
-        with:
-          name: Unity Tests
-          path: test-results/**/*.xml
-          reporter: dotnet-nunit
-
-      - name: Upload Test Results (artifact)
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: Test Results
-          path: test-results
-
   build:
     name: Build Unity Project
+    if: ${{ github.event.workflow_run.conclusion == 'success' }} # Only run if the 'Run Unity Tests' workflow succeeded
     runs-on: ubuntu-latest
-    needs: test # 確保只有測試成功才會 build
 
     steps:
-      # Checkout repository
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          repository: ${{ github.event.workflow_run.head_repository.full_name }}
+          ref: ${{ github.event.workflow_run.head_sha }}
           lfs: true
 
-      # Cache Library folder
       - name: Cache Library folder
         uses: actions/cache@v4
         with:
           path: Library
-          key: Library-${{ hashFiles('Assets/**', 'Packages/**', 'ProjectSettings/**') }}
+          key: Library-build-${{ hashFiles('Assets/**', 'Packages/**', 'ProjectSettings/**') }}
           restore-keys: |
-            Library-
+            Library-build-
 
-      # Build Unity project
       - name: Build project
         uses: game-ci/unity-builder@v4
         env:
@@ -84,10 +39,11 @@ jobs:
         with:
           targetPlatform: StandaloneWindows64
           customImage: unityci/editor:ubuntu-2022.3.6f1-windows-mono-3.0.1
+          # Optional: specify output path
+          # outputPath: build 
 
-      # Upload build artifacts
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: Build
-          path: build/StandaloneWindows64
+          name: Build-StandaloneWindows64 # Artifact name
+          path: build/StandaloneWindows64 # Path to the build output

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: CI-Build
 
 on:
-  workflow_run:
+  workflow_call:
   workflow_dispatch:    # 加入這行來允許手動觸發
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,23 +1,14 @@
 name: CI-Build
 
 on:
-  push:
-    branches:
-      - '*'
-  pull_request:
-    branches:
-      - '*'  
   workflow_run:
-    workflows: ["CI-Test"]
-    types:
-      - completed
+  workflow_dispatch:    # 加入這行來允許手動觸發
 
 jobs:
   build:
     name: Build Unity Project
-    if: ${{ github.event.workflow_run.conclusion == 'success' }} 
     runs-on: ubuntu-latest
-
+    
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -30,9 +21,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: Library
-          key: Library-build-${{ hashFiles('Assets/**', 'Packages/**', 'ProjectSettings/**') }}
+          key: Library-CI-${{ hashFiles('Assets/**', 'Packages/**', 'ProjectSettings/**') }}
           restore-keys: |
-            Library-build-
+            Library-CI-
 
       - name: Build project
         uses: game-ci/unity-builder@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,13 @@ name: CI-Build
 
 on:
   workflow_call:
+    secrets:
+      UNITY_LICENSE:
+        required: true
+      UNITY_EMAIL:
+        required: true
+      UNITY_PASSWORD:
+        required: true    
   workflow_dispatch:    # 加入這行來允許手動觸發
 
 jobs:

--- a/.github/workflows/daily_build.yml
+++ b/.github/workflows/daily_build.yml
@@ -1,0 +1,88 @@
+name: Daily Build
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # Runs at midnight UTC every day
+  workflow_dispatch: # Allows manual triggering
+
+jobs:
+  test:
+    name: Daily Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Cache Library for Test
+        uses: actions/cache@v4
+        with:
+          path: Library
+          key: Library-daily-${{ github.run_id }}-${{ github.sha }}-${{ hashFiles('Assets/**', 'Packages/**', 'ProjectSettings/**') }}
+          restore-keys: |
+            Library-daily-${{ github.run_id }}-${{ github.sha }}-
+            Library-daily-${{ github.run_id }}-
+
+      - name: Run tests
+        uses: game-ci/unity-test-runner@v4
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+        with:
+          customImage: unityci/editor:ubuntu-2022.3.6f1-windows-mono-3.0.1
+          testMode: all
+          artifactsPath: daily-test-results
+
+      - name: Publish Unity Test Report
+        if: always()
+        uses: dorny/test-reporter@v2
+        with:
+          name: Daily Unity Tests
+          path: daily-test-results/**/*.xml
+          reporter: dotnet-nunit
+
+      - name: Upload Test Results (artifact)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: Daily Test Results
+          path: daily-test-results
+
+  build:
+    name: Daily Build
+    runs-on: ubuntu-latest
+    needs: test # Depends on the 'test' job completing successfully
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Cache Library for Build
+        uses: actions/cache@v4
+        with:
+          path: Library
+          key: Library-daily-${{ github.run_id }}-${{ github.sha }}-${{ hashFiles('Assets/**', 'Packages/**', 'ProjectSettings/**') }}
+          restore-keys: |
+            Library-daily-${{ github.run_id }}-${{ github.sha }}-
+            Library-daily-${{ github.run_id }}-
+
+      - name: Build project
+        uses: game-ci/unity-builder@v4
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+        with:
+          targetPlatform: StandaloneWindows64
+          customImage: unityci/editor:ubuntu-2022.3.6f1-windows-mono-3.0.1
+          # Optional: specify output path
+          # outputPath: daily-build 
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: Daily-Build-StandaloneWindows64
+          path: build/StandaloneWindows64

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI-Test
 
 on:
   push:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,54 @@
+name: Run Unity Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    name: Run Unity Tests # This name is important for the build.yml trigger
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Cache Library folder
+        uses: actions/cache@v4
+        with:
+          path: Library
+          key: Library-test-${{ hashFiles('Assets/**', 'Packages/**', 'ProjectSettings/**') }}
+          restore-keys: |
+            Library-test-
+
+      - name: Run tests
+        uses: game-ci/unity-test-runner@v4
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+        with:
+          customImage: unityci/editor:ubuntu-2022.3.6f1-windows-mono-3.0.1
+          testMode: all
+          artifactsPath: test-results
+
+      - name: Publish Unity Test Report
+        if: always()
+        uses: dorny/test-reporter@v2
+        with:
+          name: Unity Tests
+          path: test-results/**/*.xml
+          reporter: dotnet-nunit
+
+      - name: Upload Test Results (artifact)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: Test Results
+          path: test-results

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Run Unity Tests
+name: CI
 
 on:
   push:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,10 +3,10 @@ name: Run Unity Tests
 on:
   push:
     branches:
-      - main
+      - '*'
   pull_request:
     branches:
-      - main
+      - '*'
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - '*'
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,3 +58,7 @@ jobs:
     needs: test      # 確保測試完成後才執行
     if: success()    # 只在測試成功時執行
     uses: ./.github/workflows/build.yml    # 呼叫建置工作流程
+    secrets:
+      UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+      UNITY_EMAIL:   ${{ secrets.UNITY_EMAIL }}
+      UNITY_PASSWORD:${{ secrets.UNITY_PASSWORD }}    

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,6 @@ jobs:
     if: success()    # 只在測試成功時執行
     uses: ./.github/workflows/build.yml    # 呼叫建置工作流程
     secrets:
-      UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
-      UNITY_EMAIL:   ${{ secrets.UNITY_EMAIL }}
-      UNITY_PASSWORD:${{ secrets.UNITY_PASSWORD }}    
+      UNITY_LICENSE:  ${{ secrets.UNITY_LICENSE }}
+      UNITY_EMAIL:    ${{ secrets.UNITY_EMAIL }}
+      UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,9 +24,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: Library
-          key: Library-test-${{ hashFiles('Assets/**', 'Packages/**', 'ProjectSettings/**') }}
+          key: Library-CI-${{ hashFiles('Assets/**', 'Packages/**', 'ProjectSettings/**') }}
           restore-keys: |
-            Library-test-
+            Library-CI-
 
       - name: Run tests
         uses: game-ci/unity-test-runner@v4
@@ -53,3 +53,8 @@ jobs:
         with:
           name: Test Results
           path: test-results
+
+  call-build:
+    needs: test      # 確保測試完成後才執行
+    if: success()    # 只在測試成功時執行
+    uses: ./.github/workflows/build.yml    # 呼叫建置工作流程


### PR DESCRIPTION
…ches

This commit updates the caching strategy within the `.github/workflows/daily_build.yml` workflow:

1.  **Unique Cache Per Workflow Run**:
    - Both the `test` job and the `build` job within `daily_build.yml` now use a cache key that incorporates `${{ github.run_id }}`.
    - The new cache key format is: `Library-daily-${{ github.run_id }}-${{ github.sha }}-${{ hashFiles('Assets/**', 'Packages/**', 'ProjectSettings/**') }}`.
    - This ensures that every execution of the `daily_build.yml` workflow generates and uses a completely new cache, preventing interference from previous runs, even if they were for the same commit SHA.

2.  **Shared Cache Within the Same Run**:
    - The `test` job and the `build` job use the identical cache key and restore-keys.
    - This allows the `test` job to populate the cache, and the subsequent `build` job (within the same workflow run) to effectively utilize this warmed-up cache.

3.  **No Changes to Other Workflows**:
    - `.github/workflows/test.yml` and `.github/workflows/build.yml` remain unchanged in this commit, as their caching strategies and functionalities are already established.

This change enhances the isolation and reliability of the daily build process by guaranteeing a fresh build environment for each scheduled execution while still optimizing for speed between the test and build stages of that specific run.