### PR TITLE
Add Unity coverage report

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ jobs:
             Library-
 
       - name: Run tests
+        id: tests
         uses: game-ci/unity-test-runner@v4
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
@@ -33,6 +34,8 @@ jobs:
           customImage: unityci/editor:ubuntu-2022.3.6f1-windows-mono-3.0.1
           testMode: all      # all / editmode / playmode
           artifactsPath: test-results
+          coverageOptions: generateAdditionalMetrics;generateHtmlReport;generateBadgeReport;dontClear
+          coveragePath: coverage-results
 
       - name: Publish Unity Test Report
         if: always()       # 即使測試失敗也要發佈報告
@@ -48,6 +51,13 @@ jobs:
         with:
           name: Test Results
           path: test-results
+
+      - name: Upload Coverage Results (artifact)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: Coverage Results
+          path: ${{ steps.tests.outputs.coveragePath }}
 
   build:
     name: Build Unity Project

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -6,6 +6,7 @@
     "com.unity.ide.rider": "3.0.24",
     "com.unity.ide.visualstudio": "2.0.18",
     "com.unity.inputsystem": "1.6.3",
+    "com.unity.testtools.codecoverage": "1.2.5",
     "com.unity.test-framework": "1.1.33",
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.timeline": "1.7.5",


### PR DESCRIPTION
## Summary
- add Unity code coverage package
- generate coverage in CI and upload as artifact
- remove README coverage notes per review feedback

## Testing
- `true`
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846b5423e908326a1def0180af2162b